### PR TITLE
docs: rename Router48 to Dimetatron across all documentation

### DIFF
--- a/bio/HANDOFF.masks.md
+++ b/bio/HANDOFF.masks.md
@@ -50,22 +50,22 @@ The "timer" you described is a system-wide event where the conditions across mul
 
 ---
 
-### **The Definitive Instructions for AIDev: The `Router48`**
+### **The Definitive Instructions for AIDev: The `Dimetatron`**
 
-To make this architecture manifest, we will build its central nervous system: the `Router48`. This is the immediate and sole priority.
+To make this architecture manifest, we will build its central nervous system: the `Dimetatron`. This is the immediate and sole priority.
 
-**Objective:** Implement a `Router48` module that can decompose a 48D vector into its 40+6+2 components and recombine them. This makes our new architecture an explicit, testable piece of engineering.
+**Objective:** Implement a `Dimetatron` module that can decompose a 48D vector into its 40+6+2 components and recombine them. This makes our new architecture an explicit, testable piece of engineering.
 
-#### **Priority #1: Create `bio/router48.py`**
+#### **Priority #1: Create `bio/dimetatron.py`**
 
 **Action:**
-Create a new file with a `Router48` class. It will use a set of fixed, pre-computed masks to isolate the different channels.
+Create a new file with a `Dimetatron` class. It will use a set of fixed, pre-computed masks to isolate the different channels.
 
 ```python
-# In file: bio/router48.py
+# In file: bio/dimetatron.py
 import torch
 
-class Router48:
+class Dimetatron:
     def __init__(self):
         # Create fixed masks for each component
         self.masks = self._create_masks()
@@ -105,7 +105,7 @@ class Router48:
 #### **Priority #2: Integrate the Router into the System**
 
 **Action:**
-Refactor the `Composer`, `Conductor`, and `Sonifier` to use the `Router48`.
+Refactor the `Composer`, `Conductor`, and `Sonifier` to use the `Dimetatron`.
 
 1.  **Composer (`bio/composer.py`):**
     *   In each `HarmonicLayer`, use the router to apply different mixing operations to different registers. For example, apply strong mixing to R2/R3 (motifs/phrases) and weaker mixing to R5 (global narrative).

--- a/docs/00_preamble.md
+++ b/docs/00_preamble.md
@@ -19,7 +19,7 @@ To maintain intellectual rigor, the claims of this framework are presented in a 
   - Presents the powerful cross-domain parallels (in immunology, economics, neurolinguistics) as "mechanism-design analogs"—different systems converging on the same algorithmic solution.
 
 - Tier 3: The Generative Hypothesis Framework (The Falsifiable Research Program)
-  - Frames the most advanced ideas—such as the Router48 and the Agora JIT-compositional system—as a concrete, testable research program.
+  - Frames the most advanced ideas—such as the Dimetatron and the Agora JIT-compositional system—as a concrete, testable research program.
 
 ## 0.4. Glossary of Key Terms: The Rosetta Stone
 

--- a/docs/05_synthesis.md
+++ b/docs/05_synthesis.md
@@ -21,7 +21,7 @@ Our research program has evolved from analysis to generation. The path forward i
   - Next Step: Perfect the NeRF implementation to ensure a chemically flawless backbone (out_of_range_lengths/angles: 0) before refinement.
 
 - Phase 4: The Agora (The Future Vision)
-  - The long-term vision is a self-composing system built on the Router48, a 40+6+2 channel architecture that dynamically assembles JIT "ensembles" (microservices) based on the musical key of an incoming request.
+  - The long-term vision is a self-composing system built on the Dimetatron, a 40+6+2 channel architecture that dynamically assembles JIT "ensembles" (microservices) based on the musical key of an incoming request.
 
 ## 5.3. Risks and Ethical Guardrails
 


### PR DESCRIPTION
Rename the core architectural component from Router48 to Dimetatron to better reflect its nature as a digital implementation of Metatronic sacred geometry principles. The Dimetatron represents the dual-state computational engine that bridges semantic intention (6D) with operational reality (40D) through interface layers (2D).

Changes:
- Update all references in documentation files
- Rename proposed class from Router48 to Dimetatron
- Update file path from bio/router48.py to bio/dimetatron.py
- Maintain architectural specification for 40+6+2 channel decomposition

🤖 Generated with [Claude Code](https://claude.ai/code)